### PR TITLE
DO NOT MERGE: Fix redirectable with blank uris

### DIFF
--- a/lib/doorkeeper/oauth/error_response.rb
+++ b/lib/doorkeeper/oauth/error_response.rb
@@ -36,6 +36,8 @@ module Doorkeeper
       end
 
       def redirectable?
+        return false if @redirect_uri.blank?
+
         name != :invalid_redirect_uri && name != :invalid_client &&
           !URIChecker.native_uri?(@redirect_uri)
       end

--- a/spec/lib/oauth/error_response_spec.rb
+++ b/spec/lib/oauth/error_response_spec.rb
@@ -8,6 +8,13 @@ module Doorkeeper::OAuth
       end
     end
 
+    describe 'the redirect uri' do
+      it 'is not redirectable when redirect uri is nil' do
+        response = ErrorResponse.new(name: :some_error, state: nil)
+        expect(response.redirectable?).to eq(false)
+      end
+    end
+
     describe :from_request do
       it 'has the error from request' do
         error = ErrorResponse.from_request double(error: :some_error)


### PR DESCRIPTION
NOTE: This PR starts from Doorkeeper 5.0.2 as a base.  This is intended to serve as a temporary source for our gem in the interim while we upgrade to Ruby 2.4+.  This branch is pointed to from our gemfile, do not merge this PR!

### Summary

We are fixing `redirectable?` returning the wrong result as a consequence of a different error name type.  This should function correctly independently of error name type.

In base Doorkeeper, there is a PR and commit that the maintainer is looking to push into the latest 5.2 that fixes the issue in one way https://github.com/doorkeeper-gem/doorkeeper/commit/444fdbed7aaf8df023a4daf0bacdd31ffb8374eb where their intent is that validations (and the error response generated) need to happen in a very specific order and would avoid running into this issue.